### PR TITLE
feat: support store accessor in vanilla vue

### DIFF
--- a/docs/accessor/customisation.md
+++ b/docs/accessor/customisation.md
@@ -32,6 +32,10 @@ export default async ({ store }: Context, inject: Inject) => {
 }
 ```
 
+::: warning
+If you are using a custom accessor in a Nuxt project, bear in mind that `useAccessor` used on its own will treat modules as non-namespaced unless they include `namespaced: true`.
+:::
+
 ## Typing your custom accessor
 
 You can use the helper function `getAccessorType` to access the type of the accessor you've generated - by passing it the exact same object that `useAccessor` receives.

--- a/docs/using-without-nuxt.md
+++ b/docs/using-without-nuxt.md
@@ -124,3 +124,22 @@ export default class SampleComponent extends Vue {
   }
 }
 ```
+
+## Usage within the store
+
+You can use the accessor within the store or a store module.
+
+```ts
+import { actionTree } from 'nuxt-typed-vuex'
+import { accessor } from '.'
+
+const actions = actionTree(
+  { state, getters, mutations },
+  {
+    async resetEmail({ commit }) {
+      accessor.submodule.initialise()
+      commit('setEmail', 'a@a.com')
+    },
+  }
+)
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+import { VueConstructor } from 'vue/types/vue'
+
+declare module 'vue/types/vue' {
+  interface VueConstructor {
+    $accessor?: any;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,0 @@
-import { VueConstructor } from 'vue/types/vue'
-
-declare module 'vue/types/vue' {
-  interface VueConstructor {
-    $accessor?: any;
-  }
-}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "normalize-path": "^3.0.0"
   },
   "peerDependencies": {
-    "@nuxt/types": "*",
     "vuex": "*"
+  },
+  "optionalDependencies": {
+    "@nuxt/types": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "normalize-path": "^3.0.0"
   },
   "peerDependencies": {
+    "vue": "*",
     "vuex": "*"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "yarn build",
     "release": "yarn test && standard-version && git push --follow-tags && npm publish",
     "generate": "yarn build && yarn nuxt generate test/fixture",
-    "test": "yarn lint && yarn generate && jest && tsc --noImplicitAny --noEmit test/accessor.test.ts"
+    "test": "yarn lint && yarn generate && jest && tsc --noImplicitAny --noEmit test/accessor.test.ts && yarn tsd"
   },
   "tsd": {
     "directory": "test/tsd"
@@ -70,7 +70,6 @@
     "normalize-path": "^3.0.0"
   },
   "peerDependencies": {
-    "vue": "*",
     "vuex": "*"
   },
   "optionalDependencies": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,12 @@ import Vuex, {
   StoreOptions,
 } from 'vuex'
 
+declare module 'vue' {
+  interface VueConstructor {
+    $accessor?: any;
+  }
+}
+
 export class TypedStore<S> extends Store<S> {
   $accessor: VueConstructor['$accessor']
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,6 @@ import Vuex, {
   Store,
   GetterTree,
   MutationTree,
-  ModuleTree,
-  Plugin,
   DispatchOptions,
   CommitOptions,
   StoreOptions,
@@ -154,7 +152,7 @@ export const getAccessorType = <
   return {} as MergedStoreType<typeof store & BlankStore>
 }
 
-const getNestedState = (parent: any, namespaces: string[] ): any => {
+const getNestedState = (parent: any, namespaces: string[]): any => {
   if (!parent[namespaces[0]]) {
     return parent
   } else {
@@ -164,7 +162,12 @@ const getNestedState = (parent: any, namespaces: string[] ): any => {
 
 const createAccessor = <T extends State, G, M, A, S extends NuxtModules>(
   store: UnifiedStore<any>,
-  { getters, state, mutations, actions }: Partial<NuxtStoreInput<T, G, M, A, S>>,
+  {
+    getters,
+    state,
+    mutations,
+    actions,
+  }: Partial<NuxtStoreInput<T, G, M, A, S>>,
   namespace = ''
 ) => {
   const namespacedPath = namespace ? `${namespace}/` : ''
@@ -209,7 +212,9 @@ export const useAccessor = <
 ) => {
   const accessor = createAccessor(store, input, namespace)
   Object.keys(input.modules || {}).forEach(moduleNamespace => {
-    const nestedNamespace = namespace ? `${namespace}/${moduleNamespace}` : moduleNamespace
+    const nestedNamespace = namespace
+      ? `${namespace}/${moduleNamespace}`
+      : moduleNamespace
     accessor[moduleNamespace] = useAccessor(
       store,
       (input.modules as any)[moduleNamespace],
@@ -266,7 +271,5 @@ export const createStore = <S>(
   return new VuexModule.Store((options as unknown) as StoreOptions<S>)
 }
 
-export const registerStoreAccessor = (
-  VuexModule: typeof Vuex,
-  accessor: any
-) => (VuexModule.Store as typeof TypedStore).prototype.$accessor = accessor
+export const registerStoreAccessor = (VuexModule: typeof Vuex, accessor: any) =>
+  ((VuexModule.Store as typeof TypedStore).prototype.$accessor = accessor)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,9 +168,12 @@ const createAccessor = <T extends State, G, M, A, S extends NuxtModules>(
       get: () => store.getters[`${namespacedPath}${getter}`],
     })
   })
-  Object.keys(
-    state ? (typeof state === 'function' ? state() : state) : {}
-  ).forEach(prop => {
+  const evaluatedState = state
+    ? typeof state === 'function'
+      ? state()
+      : state
+    : {}
+  Object.keys(evaluatedState).forEach(prop => {
     if (!Object.getOwnPropertyNames(accessor).includes(prop)) {
       const namespaces = namespacedPath.split('/')
       const state = getNestedState(store.state, namespaces)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,6 +57,7 @@ interface NuxtStoreInput<
   A,
   S extends { [key: string]: Partial<NuxtStore> }
 > {
+  namespaced?: boolean;
   state: T;
   getters?: G;
   mutations?: M;
@@ -158,10 +159,11 @@ const createAccessor = <T extends State, G, M, A, S extends NuxtModules>(
     state,
     mutations,
     actions,
+    namespaced,
   }: Partial<NuxtStoreInput<T, G, M, A, S>>,
   namespace = ''
 ) => {
-  const namespacedPath = namespace ? `${namespace}/` : ''
+  const namespacedPath = namespace && namespaced ? `${namespace}/` : ''
   const accessor: Record<string, any> = {}
   Object.keys(getters || {}).forEach(getter => {
     Object.defineProperty(accessor, getter, {
@@ -175,7 +177,7 @@ const createAccessor = <T extends State, G, M, A, S extends NuxtModules>(
     : {}
   Object.keys(evaluatedState).forEach(prop => {
     if (!Object.getOwnPropertyNames(accessor).includes(prop)) {
-      const namespaces = namespacedPath.split('/')
+      const namespaces = namespace.split('/')
       const state = getNestedState(store.state, namespaces)
       Object.defineProperty(accessor, prop, {
         get: () => state[prop],
@@ -209,11 +211,10 @@ export const useAccessor = <
     const nestedNamespace = namespace
       ? `${namespace}/${moduleNamespace}`
       : moduleNamespace
-    const namespaced = (input.modules as any)[moduleNamespace].namespaced
     accessor[moduleNamespace] = useAccessor(
       store,
       (input.modules as any)[moduleNamespace],
-      namespaced ? nestedNamespace : ''
+      nestedNamespace
     )
   })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import Vuex, {
+import {
   Store,
   GetterTree,
   MutationTree,
@@ -209,10 +209,11 @@ export const useAccessor = <
     const nestedNamespace = namespace
       ? `${namespace}/${moduleNamespace}`
       : moduleNamespace
+    const namespaced = (input.modules as any)[moduleNamespace].namespaced
     accessor[moduleNamespace] = useAccessor(
       store,
       (input.modules as any)[moduleNamespace],
-      nestedNamespace
+      namespaced ? nestedNamespace : ''
     )
   })
 
@@ -265,9 +266,3 @@ export const actionTree = <
   _store: NuxtStoreInput<S, G, M, {}, {}>,
   tree: T
 ) => tree as NormalisedActionTree<T>
-
-class TypedStore<S> extends Store<S> {
-  $accessor: unknown
-}
-export const registerStoreAccessor = (VuexModule: typeof Vuex, accessor: any) =>
-  ((VuexModule.Store as typeof TypedStore).prototype.$accessor = accessor)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
 import Vuex, {
   Store,
   GetterTree,
-  ActionTree,
   MutationTree,
+  ActionTree,
   DispatchOptions,
   CommitOptions,
 } from 'vuex'
@@ -202,7 +202,7 @@ export const useAccessor = <
 >(
   store: Store<any>,
   input: Partial<NuxtStoreInput<T, G, M, A, S>>,
-  namespace?: string
+  namespace?: string,
 ) => {
   const accessor = createAccessor(store, input, namespace)
   Object.keys(input.modules || {}).forEach(moduleNamespace => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { VueConstructor } from 'vue/types/vue'
+import { VueConstructor } from 'vue'
 import Vuex, {
   Store,
   GetterTree,
@@ -150,7 +150,7 @@ export const getAccessorType = <
   T extends State,
   G extends GetterTree<StateType<T>, any>,
   M extends MutationTree<StateType<T>>,
-  A extends ModifiedActionTree<any>,
+  A extends ModifiedActionTree<Partial<NuxtStoreInput<T, G, M, A, S>> & BlankStore>,
   S extends NuxtModules
 >(
   store: Partial<NuxtStoreInput<T, G, M, A, S>>

--- a/test/accessor.test.ts
+++ b/test/accessor.test.ts
@@ -68,10 +68,30 @@ describe.only('accessor', () => {
   test('accessor submodule state, getter, mutation and actions work', async () => {
     submoduleBehaviour(accessor.submodule)
   })
+  test('namespaced modules work', async () => {
+    const nonNamespacedPattern = {
+      getters,
+      state,
+      actions,
+      mutations,
+      modules: {
+        submodule: {
+          ...submodule,
+          namespaced: false,
+        },
+      },
+    }
+    const nonNamespacedStore = new Store(nonNamespacedPattern)
+    const nonNamespacedAccessor = useAccessor(
+      nonNamespacedStore,
+      nonNamespacedPattern
+    )
+    submoduleBehaviour(nonNamespacedAccessor.submodule)
+  })
   test('nested modules work', async () => {
     submoduleBehaviour(accessor.submodule.nestedSubmodule)
   })
-  test('dynamic modules work', async () => {
+  test('namespaced dynamic modules work', async () => {
     store.registerModule('submodule', submodule)
     const dynamicAccessor = useAccessor(store, {
       modules: { submodule: { ...submodule, namespaced: true } },

--- a/test/accessor.test.ts
+++ b/test/accessor.test.ts
@@ -1,12 +1,7 @@
-import  { useAccessor, getAccessorType  } from '../'
+import { useAccessor, getAccessorType } from '../'
 import Vuex, { Store } from 'vuex'
 import Vue from 'vue'
-import {
-  getters,
-  state,
-  actions,
-  mutations,
-} from './fixture/store'
+import { getters, state, actions, mutations } from './fixture/store'
 
 import * as submodule from './fixture/store/submodule'
 
@@ -23,8 +18,8 @@ const pattern = {
         nestedSubmodule: {
           ...submodule,
           namespaced: true,
-        }
-      }
+        },
+      },
     },
   },
 }
@@ -33,16 +28,16 @@ const accessorType = getAccessorType(pattern)
 const submoduleAccessorType = getAccessorType(submodule)
 
 const submoduleBehaviour = (accessor: typeof submoduleAccessorType) => {
-    expect(accessor.firstName).toEqual('')
-    accessor.setFirstName('Nina')
-    expect(accessor.firstName).toEqual('Nina')
-    accessor.setLastName('Willis')
-    expect(accessor.fullName).toEqual('Nina Willis')
-    
-    accessor.initialise()
-    expect(accessor.fullName).toEqual('John Baker')
-    accessor.setName('Jordan Lawrence')
-    expect(accessor.firstName).toEqual('Jordan')
+  expect(accessor.firstName).toEqual('')
+  accessor.setFirstName('Nina')
+  expect(accessor.firstName).toEqual('Nina')
+  accessor.setLastName('Willis')
+  expect(accessor.fullName).toEqual('Nina Willis')
+
+  accessor.initialise()
+  expect(accessor.fullName).toEqual('John Baker')
+  accessor.setName('Jordan Lawrence')
+  expect(accessor.firstName).toEqual('Jordan')
 }
 
 describe.only('accessor', () => {
@@ -78,7 +73,9 @@ describe.only('accessor', () => {
   })
   test('dynamic modules work', async () => {
     store.registerModule('submodule', submodule)
-    const dynamicAccessor = useAccessor(store, { modules: { submodule } })
+    const dynamicAccessor = useAccessor(store, {
+      modules: { submodule: { ...submodule, namespaced: true } },
+    })
 
     submoduleBehaviour(dynamicAccessor.submodule)
   })


### PR DESCRIPTION
This adds support for using an injected accessor in the vanilla vue store.

**Edit:** This is no longer a breaking change.

#20