### PR TITLE
fix: state lazy evaluation in accessor

### DIFF
--- a/packages/typed-vuex/src/accessor.ts
+++ b/packages/typed-vuex/src/accessor.ts
@@ -49,9 +49,8 @@ const createAccessor = <T extends State, G, M, A, S extends NuxtModules>(
   Object.keys(evaluatedState).forEach(prop => {
     if (!Object.getOwnPropertyNames(accessor).includes(prop)) {
       const namespaces = namespace.split('/')
-      const state = getNestedState(store.state, namespaces)
       Object.defineProperty(accessor, prop, {
-        get: () => state[prop],
+        get: () => getNestedState(store.state, namespaces)[prop],
       })
     }
   })


### PR DESCRIPTION
This pull request fix #71 

Since the state was being evaluated when `createAccessor` was called, subsequent changes seemed to be ignored.

https://codesandbox.io/s/17967
will work with this fix.